### PR TITLE
Reintroduce laziness into the "Collection Organization" view

### DIFF
--- a/public/app/assets/javascripts/infinite_scroll.js
+++ b/public/app/assets/javascripts/infinite_scroll.js
@@ -1,3 +1,5 @@
+// NOTE: This file is not being used by Yale's collection organization page.  See waypoint_loader.js.
+
 (function (exports) {
   var BATCH_SIZE = 2;
   var SCROLL_DELAY_MS = 50;

--- a/public/app/assets/stylesheets/archivesspace/aspace.scss
+++ b/public/app/assets/stylesheets/archivesspace/aspace.scss
@@ -1129,6 +1129,28 @@ span.head {
   .infinite-record-context-selector {
     height: 60px;
     box-shadow: 1px 1px 5px rgba(0,0,0,0.3);
+    position: relative;
+
+    .waypoint-loading-spinner {
+      position: absolute;
+      right: 60px;
+      top: 16px;
+
+      width: 30px;
+      height: 30px;
+      --b: 6px;
+      aspect-ratio: 1;
+      border-radius: 50%;
+      padding: 1px;
+      background: conic-gradient(#0000 10%,#666) content-box;
+      -webkit-mask:
+              repeating-conic-gradient(#0000 0deg,#000 1deg 20deg,#0000 21deg 36deg),
+              radial-gradient(farthest-side,#0000 calc(100% - var(--b) - 1px),#000 calc(100% - var(--b)));
+      -webkit-mask-composite: destination-in;
+      mask-composite: intersect;
+      animation:l4 1s infinite steps(10);
+    }
+    @keyframes l4 {to{transform: rotate(1turn)}}
   }
 }
 

--- a/public/app/assets/stylesheets/archivesspace/infinite-scroll.scss
+++ b/public/app/assets/stylesheets/archivesspace/infinite-scroll.scss
@@ -4,8 +4,13 @@
   will-change: transform;
 
   .waypoint {
-    height: auto;
+    height: 200px;
   }
+
+  .waypoint.populated {
+    height: auto !important;
+  }
+
 }
 
 .infinite-record-scrollbar {
@@ -88,19 +93,4 @@ $indent-width: 20px;
     background: #FAFAFA;
     width: 100%;
     border: 4px;
-}
-
-.waypoint:last-child {
-  .infinite-record-record:last-child {
-    &::after {
-      content: '';
-      border-bottom: 5px solid #ccc;
-      width: 90%;
-      left: 5%;
-      display: block;
-      padding-top: 40px;
-      background: #fff;
-      position: absolute;
-    }
-  }
 }

--- a/public/app/controllers/resources_controller.rb
+++ b/public/app/controllers/resources_controller.rb
@@ -201,6 +201,7 @@ class ResourcesController < ApplicationController
         {:uri => nil, :crumb => process_mixed_content(@result.display_string), type: @result.primary_type}]
       fill_request_info
       @ordered_records = archivesspace.get_record(@root_uri + '/ordered_records').json.fetch('uris')
+
       @ordered_records.shift # drop resource as rendered by default
     rescue RecordNotFound
       record_not_found(uri, 'resource')
@@ -209,7 +210,7 @@ class ResourcesController < ApplicationController
 
   def waypoints
     search_opts = {
-      'resolve[]' => ['top_container_uri_u_sstr:id'],
+      'resolve[]' => ['top_container_uri_u_sstr:id', 'ancestors:id@compact_resource'],
     }
 
     waypoint_uris = params[:urls]
@@ -234,9 +235,11 @@ class ResourcesController < ApplicationController
       format.json do
         render :json => Hash[results.records.map {|record|
           @result = record
+
           record_number = (waypoint_number * waypoint_size) + waypoint_uris.index(@result.uri) + 1
           [record.uri,
-           render_to_string(:partial => 'infinite_item',
+           render_to_string(:partial => 'infinite_item_json',
+                            :formats => :html,
                             :locals => {
                               :record_number =>  record_number,
                               :collection_size =>  collection_size

--- a/public/app/helpers/record_helper.rb
+++ b/public/app/helpers/record_helper.rb
@@ -42,7 +42,7 @@ module RecordHelper
   def record_from_resolved_json(json, full = false)
     record_for_type({
                       'json' => json,
-                      'primary_type' => json.fetch('jsonmodel_type'),
+                      'primary_type' => json.fetch('jsonmodel_type', nil),
                       'uri' => json.fetch('uri')
                     }, full)
   end

--- a/public/app/models/concerns/tree_nodes.rb
+++ b/public/app/models/concerns/tree_nodes.rb
@@ -61,6 +61,16 @@ module TreeNodes
     }).compact
   end
 
+  def ancestors_with_level
+    ancestors.reverse.map do |ancestor|
+      {
+        :ref => ancestor['uri'],
+        :level => ancestor['level'],
+      }
+    end
+  end
+
+
   private
 
   def id

--- a/public/app/models/resource.rb
+++ b/public/app/models/resource.rb
@@ -186,6 +186,10 @@ class Resource < Record
     archives_space_client.get_all_series(uri)
   end
 
+  def ancestors_with_level
+    []
+  end
+
   private
 
   def parse_digital_instance

--- a/public/app/views/resources/_infinite_item_json.html.erb
+++ b/public/app/views/resources/_infinite_item_json.html.erb
@@ -1,0 +1,8 @@
+<div class="infinite-record-record" id="record-number-<%= record_number %>" data-record-number="<%= record_number %>" data-level="<%= @result.level %>" data-uri="<%= @result['uri'] %>" data-ancestors="<%=h @result.ancestors_with_level.to_json %>">
+  <%= render partial: 'resources/infinite_item',
+             locals: {
+               record_number: record_number,
+               collection_size: collection_size
+             }
+  %>
+</div>

--- a/public/app/views/resources/infinite.html.erb
+++ b/public/app/views/resources/infinite.html.erb
@@ -42,6 +42,7 @@
               <% end %>
             </ul>
           </div>
+          <span class="waypoint-loading-spinner" style="display: none"></span>
         </div>
       </div>
     </nav>


### PR DESCRIPTION
Large collections end up triggering lots of AJAX requests, and when we do these eagerly they overwhelm the database connection pool.

Revert to doing lazy loading, but introduce some improvements to make series-level navigation more reliable.
