### PR TITLE
Optimize handling of deletes against Solr

### DIFF
--- a/indexer/app/lib/indexer_common.rb
+++ b/indexer/app/lib/indexer_common.rb
@@ -31,6 +31,24 @@ class IndexerCommon
 
   @@paused_until = Time.now
 
+  # Solr stores deletes and applies them at commit time.  If you go a long time
+  # between commits, this can cause OOM issues and/or long commit times as
+  # thousands of deletes are finally applied.
+  #
+  # To avoid this, we'll force a Solr commit when we hit a certain number of deletes.
+  #
+  # Fun fact: our solrconfig.xml has a <maxPendingDeletes> set, but it doesn't
+  # appear to do anything anymore.  There's a JIRA suggesting the feature did
+  # exist at some point: https://issues.apache.org/jira/browse/SOLR-310.
+  #
+  # So we're essentially reimplementing that feature here.
+  MAX_PENDING_DELETES = AppConfig.has_key?(:indexer_max_pending_deletes) ? AppConfig[:indexer_max_pending_deletes] : 10000
+
+  # Our best estimate of the number of deletes we have queued up.  It's an
+  # estimate because sometimes we delete by query and don't know exactly how
+  # many hits there will be.
+  @@pending_delete_estimate = java.util.concurrent.atomic.AtomicLong.new(0)
+
   def self.add_indexer_initialize_hook(&block)
     @@init_hooks << block
   end
@@ -1103,10 +1121,53 @@ class IndexerCommon
       hook.call(records, delete_request)
     end
 
+    @@pending_delete_estimate.addAndGet(delete_request.fetch(:delete).length)
+
+    # In delete_request, we have an array of individual requests like:
+    #
+    #   {:delete=>
+    #     [{"id"=>"/some/uri/123"},
+    #      {"query"=>"parent_id:\"/some/uri/123\""},
+    #      {"id"=>"/some/uri/456"},
+    #      {"query"=>"parent_id:\"/some/uri/456\""},
+    #      ...]}
+    #
+    # And since delete hooks assume this format, I didn't want to change it.
+    # But...
+    #
+    # Solr processes each delete one at a time, at commit time, on a single
+    # thread.  The id deletes are quite cheap, but the query-based deletes take
+    # substantially longer (20ms+) because each one looks up the schema, gets an
+    # index reader, opens a searcher, parses a query, etc..  Solr performs no
+    # batching internally.
+    #
+    # So, we group them into boolean clauses here to amortize the cost of all of
+    # that.
+
+    id_deletes = delete_request.fetch(:delete).select {|r| r['id']}
+    grouped_queries = delete_request
+                        .fetch(:delete)
+                        .map {|r| r['query']}
+                        .compact
+                        .each_slice(512)
+                        .map do |clause_group|
+      {'query' => clause_group.join(" OR ")}
+    end
+
+    delete_request = {:delete => id_deletes + grouped_queries}
+
     req.body = delete_request.to_json
 
     response = do_http_request(solr_url, req)
 
+    # If there are lots of pending deletes, fire a commit to clear them out
+    # before they get too numerous.  See the comment on MAX_PENDING_DELETES for
+    # more detail.
+    pending_deletes = @@pending_delete_estimate.get
+    if pending_deletes >= MAX_PENDING_DELETES && @@pending_delete_estimate.compareAndSet(pending_deletes, 0)
+      Log.info "Sending soft commit to apply deletes to Solr"
+      send_commit(:soft)
+    end
 
     if response.code == '200'
       Log.info "Deleted #{records.length} documents: #{response}"

--- a/indexer/app/lib/periodic_indexer.rb
+++ b/indexer/app/lib/periodic_indexer.rb
@@ -225,11 +225,12 @@ class PeriodicIndexer < IndexerCommon
         }
 
         # Commit if anything was added to Solr
+        commit_start_time = Time.now
         unless worker_statuses.all? {|status| status == WORKER_STATUS_NOTHING_INDEXED}
           send_commit
         end
 
-        log("Indexed #{id_set.length} records in #{Time.now.to_i - start.to_i} seconds")
+        log("Indexed #{id_set.length} records in #{Time.now.to_i - start.to_i} seconds (commit time: #{sprintf('%.2f', Time.now.to_f - commit_start_time.to_f)} seconds)")
 
         if worker_statuses.include?(WORKER_STATUS_INDEX_ERROR)
           Log.info("Skipping update of indexer state for record type #{type} in repository #{repository.id} due to previous failures")          


### PR DESCRIPTION
Solr stores deletes and applies them at commit time.  If you go a long time between commits, this can cause OOM issues and/or long commit times as thousands of deletes are finally applied.

To avoid these issues, apply periodic soft commits against Solr to force it to process deletes, and rewrite our delete queries into wider OR clauses to amortize the cost of doing queries.
